### PR TITLE
Added 60dB integration

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -2,3 +2,14 @@ DEEPGRAM_API_KEY=''
 GROQ_API_KEY=''
 PLAY_API_KEY=''
 NEETS_API=''
+
+# TTS provider: 'playht' (default) or '60db'
+TTS_PROVIDER='playht'
+
+# 60db TTS (used when TTS_PROVIDER=60db)
+DB60_API_KEY=''
+DB60_VOICE_ID=''
+# optional tuning (defaults: speed=1, stability=50, similarity=75)
+DB60_SPEED='1'
+DB60_STABILITY='50'
+DB60_SIMILARITY='75'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ## Features
 - Fast AI Voice Assistant, takes <1 second to reply back to you.
 - Built using Node.js and Websockets.
-- AI Voice Assistant makes use of Groq API(AI models), deepgram api(STT) and playHT/neets API (TTS)
+- AI Voice Assistant makes use of Groq API(AI models), deepgram api(STT) and playHT/60db/neets API (TTS)
+- Switchable TTS provider: choose between **PlayHT** and **60db** via the `TTS_PROVIDER` env variable (Deepgram STT and Groq LLM stay the same).
 - The voice assistance that actually listens to you when you speak or interrupt the assistant.
 - Uses LLama 3 70b/8b or gemma 7b AI models.
 - Has memory of your past conversations.
@@ -18,6 +19,31 @@
   - playht_api and playht_userId https://play.ht
   - deepgram_api https://console.deepgram.com
   - neets_api https://neets.ai/studio
+  - 60db_api https://60db.ai (used when `TTS_PROVIDER=60db`)
+
+  ### Choose your TTS provider:
+  Set `TTS_PROVIDER` in the env file to pick which voice the assistant speaks with.
+
+  **PlayHT (default):**
+  ```
+  TTS_PROVIDER=playht
+  PLAY_API_KEY=your_playht_key
+  PLAY_USERID=your_playht_userid
+  ```
+
+  **60db:**
+  ```
+  TTS_PROVIDER=60db
+  DB60_API_KEY=your_60db_key
+  DB60_VOICE_ID=your_60db_voice_id
+  # optional tuning (defaults shown)
+  DB60_SPEED=1
+  DB60_STABILITY=50
+  DB60_SIMILARITY=75
+  ```
+  60db uses the streaming `POST /tts-stream` endpoint and returns mp3 audio, so it
+  plugs into the same playback/interruption pipeline as PlayHT — no other changes needed.
+  Get a voice id from the `GET /myvoices` endpoint or the 60db dashboard.
 
   ### Start the Assistant
   ``` npm run start ```
@@ -28,4 +54,5 @@
 - [Groq API](https://groq.com)
 - [Deepgram API](https://deepgram.com)
 - [PlayHT API](https://play.ht)
+- [60db API](https://60db.ai)
 - [Neets API](https://neets.ai/studio)

--- a/models/sixtydb.js
+++ b/models/sixtydb.js
@@ -1,0 +1,128 @@
+const https = require('https');
+const { PassThrough } = require('stream');
+
+// 60db streaming TTS provider.
+// Mirrors the playht module: initialize() + play(text) -> Node Readable of mp3 bytes,
+// so it drops straight into server.js's play_stream() (stream.on('data', ...)).
+//
+// Docs: POST https://api.60db.ai/tts-stream  -> NDJSON lines:
+//   { "type": "chunk", "audioContent": "<base64>" }   (audio piece)
+//   { "type": "complete" }                              (done)
+//   { "type": "error",  "message": "..." }              (failure)
+// The exact nesting isn't fully pinned down in the docs, so the parser below is
+// tolerant of a few likely shapes (audioContent at top level or under chunk/data).
+
+const TTS_STREAM_URL = 'https://api.60db.ai/tts-stream';
+
+async function initialize() {
+  console.log('60db: initializing');
+  if (!process.env.DB60_API_KEY || !process.env.DB60_VOICE_ID) {
+    console.error('Please provide DB60_API_KEY and DB60_VOICE_ID in the env file');
+    process.exit(1);
+  }
+}
+
+// Pull base64 audio out of an NDJSON message regardless of which shape 60db uses.
+function extractAudio(msg) {
+  if (typeof msg.audioContent === 'string') return msg.audioContent;
+  if (msg.chunk && typeof msg.chunk.audioContent === 'string') return msg.chunk.audioContent;
+  if (msg.data && typeof msg.data.audioContent === 'string') return msg.data.audioContent;
+  if (typeof msg.chunk === 'string') return msg.chunk; // chunk holds the base64 directly
+  return null;
+}
+
+function isError(msg) {
+  return msg.type === 'error' || msg.error !== undefined;
+}
+
+function errorMessage(msg) {
+  return msg.message || (msg.error && (msg.error.message || msg.error)) || '60db tts-stream error';
+}
+
+function handleLine(line, out) {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch (e) {
+    return; // ignore non-JSON / partial lines
+  }
+
+  if (isError(msg)) {
+    out.destroy(new Error(errorMessage(msg)));
+    return;
+  }
+
+  const audio = extractAudio(msg);
+  if (audio) {
+    out.write(Buffer.from(audio, 'base64'));
+  }
+  // a "complete" message just means no more audio; out.end() fires on response 'end'
+}
+
+async function play(text) {
+  // PassThrough lets us return a Node Readable immediately while we decode chunks into it.
+  const out = new PassThrough();
+
+  const body = JSON.stringify({
+    text,
+    voice_id: process.env.DB60_VOICE_ID,
+    output_format: 'mp3', // keep mp3 so the browser's audio/mpeg MediaSource pipeline is unchanged
+    enhance: true,
+    speed: Number(process.env.DB60_SPEED || 1),
+    stability: Number(process.env.DB60_STABILITY || 50),
+    similarity: Number(process.env.DB60_SIMILARITY || 75),
+  });
+
+  const req = https.request(
+    TTS_STREAM_URL,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.DB60_API_KEY}`,
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    },
+    (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        let errBody = '';
+        res.setEncoding('utf8');
+        res.on('data', (d) => (errBody += d));
+        res.on('end', () =>
+          out.destroy(new Error(`60db tts-stream HTTP ${res.statusCode}: ${errBody}`))
+        );
+        return;
+      }
+
+      let buffer = '';
+      res.setEncoding('utf8');
+      res.on('data', (data) => {
+        buffer += data;
+        let idx;
+        // process every complete NDJSON line; keep the remainder buffered
+        while ((idx = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 1);
+          if (line) handleLine(line, out);
+        }
+      });
+      res.on('end', () => {
+        const tail = buffer.trim();
+        if (tail) handleLine(tail, out);
+        out.end();
+      });
+      res.on('error', (e) => out.destroy(e));
+    }
+  );
+
+  req.on('error', (e) => out.destroy(e));
+  req.write(body);
+  req.end();
+
+  return out;
+}
+
+module.exports = {
+  play,
+  initialize,
+};

--- a/models/tts.js
+++ b/models/tts.js
@@ -1,0 +1,29 @@
+// TTS provider selector.
+// Set TTS_PROVIDER in the env to switch the voice the assistant speaks with:
+//   TTS_PROVIDER=playht   (default)  -> models/playht.js
+//   TTS_PROVIDER=60db                -> models/sixtydb.js
+//
+// Both providers expose the same contract:
+//   initialize(): Promise<void>            -- validate keys / set up the client
+//   play(text):   Promise<Readable>        -- Node stream of mp3 bytes
+// so server.js stays identical regardless of which one is active.
+
+const playht = require('./playht');
+const sixtydb = require('./sixtydb');
+
+const provider = (process.env.TTS_PROVIDER || 'playht').toLowerCase();
+
+const providers = {
+  playht,
+  '60db': sixtydb,
+  sixtydb,
+};
+
+const impl = providers[provider] || playht;
+
+console.log(`tts: using provider "${impl === playht ? 'playht' : '60db'}"`);
+
+module.exports = {
+  play: impl.play,
+  initialize: impl.initialize,
+};

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const WebSocket = require("ws");
 const fs = require('fs');
 const { createClient, LiveTranscriptionEvents } = require("@deepgram/sdk");
 const dotenv = require("dotenv");
-const {play , initialize} = require('./models/playht');
+const {play , initialize} = require('./models/tts');
 // const {neets} = require('./models/neets');
 
 
@@ -23,8 +23,10 @@ let sid2=0;
 let pl1=0;
 let pl2=0;
 
-if(!process.env.DEEPGRAM_API_KEY && !process.env.GROQ_API_KEY && !process.env.PLAY_API_KEY && !process.env.PLAY_USERID){
-    console.error('Please provide all the required keys in the .env file')
+// Core keys are always required. TTS keys are validated by the selected
+// provider in initialize() (see models/tts.js), so they aren't checked here.
+if(!process.env.DEEPGRAM_API_KEY || !process.env.GROQ_API_KEY){
+    console.error('Please provide DEEPGRAM_API_KEY and GROQ_API_KEY in the env file')
     process.exit(1);
 }
 


### PR DESCRIPTION
Added a switchable TTS provider so the assistant can speak via either PlayHT or 60db, chosen with the TTS_PROVIDER env variable.
  Deepgram (STT) and Groq (LLM) are unchanged.

  - models/sixtydb.js — 60db provider that streams POST /tts-stream, decodes the mp3 chunks, and returns them as a drop-in
  replacement for PlayHT.
  - models/tts.js — selector that loads PlayHT or 60db based on TTS_PROVIDER.
  - server.js — switched to the new selector; TTS keys now validated per provider.
  - .env.local + README.md — added DB60_* config and provider docs.